### PR TITLE
Add missing androidTestCompile libraries

### DIFF
--- a/AuthenticatorApp/build.gradle
+++ b/AuthenticatorApp/build.gradle
@@ -19,4 +19,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        androidTestCompile "org.mockito:mockito-core:1.9.5"
+    }
 }

--- a/AuthenticatorApp/build.gradle
+++ b/AuthenticatorApp/build.gradle
@@ -26,5 +26,7 @@ android {
 
     dependencies {
         androidTestCompile "org.mockito:mockito-core:1.9.5"
+        androidTestCompile "com.google.dexmaker:dexmaker:1.2"
+        androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
     }
 }


### PR DESCRIPTION
Since conversion to Android Studio 1.1.0, the test-builds did not work, since required libraries were missing from the `androidTestCompile` dependencies.

This pull request adds the required libraries, the tests run on my device and in an emulator. Some fail, though, but these seem to be related to some changes since Android 4.3, I think.