### PR TITLE
Add build flavors "playStore", "openSource", and "openSourceDev"

### DIFF
--- a/AuthenticatorApp/build.gradle
+++ b/AuthenticatorApp/build.gradle
@@ -13,6 +13,19 @@ android {
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
     }
 
+    productFlavors {
+        playStore {
+        }
+        openSource {
+            applicationId "com.google.android.apps.authenticator2.os"
+            testApplicationId "com.google.android.apps.authenticator2.tests.os"
+        }
+        openSourceDev {
+            applicationId "com.google.android.apps.authenticator2.osdev"
+            testApplicationId "com.google.android.apps.authenticator2.tests.osdev"
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/AuthenticatorApp/src/androidTest/AndroidManifest.xml
+++ b/AuthenticatorApp/src/androidTest/AndroidManifest.xml
@@ -19,9 +19,9 @@
       android:versionCode="1"
       android:versionName="1.0">
     <uses-sdk android:minSdkVersion="7" />
-    <instrumentation android:targetPackage="com.google.android.apps.authenticator2"
+    <instrumentation android:targetPackage="com.google.android.apps.authenticator2.osdev"
                      android:name="android.test.InstrumentationTestRunner" />
-    <instrumentation android:targetPackage="com.google.android.apps.authenticator2"
+    <instrumentation android:targetPackage="com.google.android.apps.authenticator2.osdev"
                      android:name="com.google.android.apps.authenticator.MockitoWorkaroundForEclairInstrumentationTestRunner" />
     <application android:label="AuthenticatorTests">
       <uses-library android:name="android.test.runner" />

--- a/AuthenticatorApp/src/androidTest/java/com/google/android/apps/authenticator/TestUtilities.java
+++ b/AuthenticatorApp/src/androidTest/java/com/google/android/apps/authenticator/TestUtilities.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.android.apps.authenticator.testability.DependencyInjector;
 import com.google.android.apps.authenticator.testability.StartActivityListener;
+import com.google.android.apps.authenticator2.BuildConfig;
 
 import android.app.Activity;
 import android.app.Instrumentation;
@@ -66,7 +67,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class TestUtilities {
 
-  public static final String APP_PACKAGE_NAME = "com.google.android.apps.authenticator2";
+  public static final String APP_PACKAGE_NAME = BuildConfig.APPLICATION_ID;
 
   /**
    * Timeout (milliseconds) when waiting for the results of a UI action performed by the code

--- a/AuthenticatorApp/src/main/res/values-v11/themes.xml
+++ b/AuthenticatorApp/src/main/res/values-v11/themes.xml
@@ -58,6 +58,6 @@
   </style>
 
   <style name="AccountListWithVerificationCodesRowCountdownIndicator">
-    <item name="com.google.android.apps.authenticator2:color">@color/countdown_indicator</item>
+    <item name="color">@color/countdown_indicator</item>
   </style>
 </resources>

--- a/AuthenticatorApp/src/main/res/values/strings.xml
+++ b/AuthenticatorApp/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+  <!-- The package of the application flavor, for use within preferences, etc. -->
+  <string name="app_package_name" translatable="false">com.google.android.apps.authenticator2</string>
+
   <!-- Name of the application -->
   <string name="app_name">Google Authenticator</string>
 

--- a/AuthenticatorApp/src/main/res/values/themes.xml
+++ b/AuthenticatorApp/src/main/res/values/themes.xml
@@ -59,6 +59,6 @@
   </style>
 
   <style name="AccountListWithVerificationCodesRowCountdownIndicator">
-    <item name="com.google.android.apps.authenticator2:color">@color/countdown_indicator</item>
+    <item name="color">@color/countdown_indicator</item>
   </style>
 </resources>

--- a/AuthenticatorApp/src/main/res/xml/preferences.xml
+++ b/AuthenticatorApp/src/main/res/xml/preferences.xml
@@ -22,7 +22,7 @@
     android:summary="@string/timesync_preference_screen_summary"
     android:persistent="false">
     <intent
-      android:targetPackage="com.google.android.apps.authenticator2"
+      android:targetPackage="@string/app_package_name"
       android:targetClass="com.google.android.apps.authenticator.timesync.SettingsTimeCorrectionActivity">
     </intent>
   </PreferenceScreen>
@@ -32,7 +32,7 @@
     android:title="@string/about_preference_title"
     android:persistent="false">
     <intent
-      android:targetPackage="com.google.android.apps.authenticator2"
+      android:targetPackage="@string/app_package_name"
       android:targetClass="com.google.android.apps.authenticator.SettingsAboutActivity">
     </intent>
   </PreferenceScreen>

--- a/AuthenticatorApp/src/main/res/xml/preferences_time_correction.xml
+++ b/AuthenticatorApp/src/main/res/xml/preferences_time_correction.xml
@@ -21,7 +21,7 @@
     android:title="@string/timesync_sync_now_preference_title"
     android:persistent="false">
     <intent
-      android:targetPackage="com.google.android.apps.authenticator2"
+      android:targetPackage="@string/app_package_name"
       android:targetClass="com.google.android.apps.authenticator.timesync.SyncNowActivity">
     </intent>
   </PreferenceScreen>
@@ -35,7 +35,7 @@
     android:title="@string/timesync_about_feature_preference_title"
     android:persistent="false">
     <intent
-      android:targetPackage="com.google.android.apps.authenticator2"
+      android:targetPackage="@string/app_package_name"
       android:targetClass="com.google.android.apps.authenticator.timesync.AboutActivity">
     </intent>
   </PreferenceScreen>

--- a/AuthenticatorApp/src/openSource/res/values/strings.xml
+++ b/AuthenticatorApp/src/openSource/res/values/strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2009 Google Inc. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+  <!-- The package of the application flavor, for use within preferences, etc. -->
+  <string name="app_package_name" translatable="false">com.google.android.apps.authenticator2.os</string>
+
+</resources>

--- a/AuthenticatorApp/src/openSourceDev/res/values/strings.xml
+++ b/AuthenticatorApp/src/openSourceDev/res/values/strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2009 Google Inc. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+  <!-- The package of the application flavor, for use within preferences, etc. -->
+  <string name="app_package_name" translatable="false">com.google.android.apps.authenticator2.osdev</string>
+
+</resources>


### PR DESCRIPTION
Since this project switched to Android Studio and Gradle as build system, I think we should use some of its advantages, namely build flavors.

This pull requests adds 3 flavors: `playStore`, `openSource`, and `openSourceDev`.

The `playStore` flavor is added for completeness, as most users of this open-source version will never be able to build the official Play Store version due to missing signing credentials.

The "openSource" and "openSourceDev" flavor use a different package name, so that they can be installed concurrently on a single device, giving the user (and us developers) the possibility to use the official Play Store version as well as a productive open-source version, while still being able to perform development tasks on a separate installation, without risking our "productive" open-source Authenticator.

Adjustments to all `themes.xml` are necessary in order to replace qualified names with references to flavor package names. There seems to be a problem within certain XML files, where package names are not replaced with the `applicationId` from the flavor (compare http://tools.android.com/tech-docs/new-build-system/applicationid-vs-packagename and http://stackoverflow.com/questions/28159281/android-gradle-applicationid-setting-causing-no-resource-found-in-themes-xml). 
Also replaces hard-coded references to package name in XML files for preferences.

The test instrumentation is hard-coded against the `openSourceDev` flavor, as I suppose this flavor is going to be used for the test runner during development. Please note, that some test cases fail at the moment, but this is unrelated to this pull request.