### PR TITLE
Add textVisiblePassword to inputType of key

### DIFF
--- a/AuthenticatorApp/src/main/res/layout/enter_key.xml
+++ b/AuthenticatorApp/src/main/res/layout/enter_key.xml
@@ -30,7 +30,7 @@
       <EditText android:id="@+id/key_value" android:layout_marginTop="5dip"
         android:layout_width="fill_parent" android:layout_height="wrap_content"
         android:hint="@string/enter_key_hint"
-        android:singleLine="true" android:inputType="textNoSuggestions"/>
+        android:singleLine="true" android:inputType="textNoSuggestions|textVisiblePassword"/>
       <Spinner android:layout_width="wrap_content" android:layout_height="wrap_content"
         android:layout_marginTop="5dip"
         android:id="@+id/type_choice" android:prompt="@string/type_prompt" />


### PR DESCRIPTION
Some very popular alternative keyboards have started to ignore the `textNoSuggestions` hint and provide auto-completion nonetheless. Adding the `textVisiblePassword` hint works around this in many cases. This is important, because adding the key to potentially backup-ed and possibly cloud-synced auto-completion information will result in the key no longer being secret.