### PR TITLE
Update Android Gradle plugin to 3.2.0

### DIFF
--- a/AuthenticatorApp/build.gradle
+++ b/AuthenticatorApp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '27.0.3'
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
@@ -14,14 +14,18 @@ android {
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
     }
 
+    flavorDimensions 'release'
     productFlavors {
         playStore {
+            dimension 'release'
         }
         openSource {
+            dimension 'release'
             applicationId "com.google.android.apps.authenticator2.os"
             testApplicationId "com.google.android.apps.authenticator2.tests.os"
         }
         openSourceDev {
+            dimension 'release'
             applicationId "com.google.android.apps.authenticator2.osdev"
             testApplicationId "com.google.android.apps.authenticator2.tests.osdev"
         }
@@ -39,8 +43,8 @@ android {
     }
 
     dependencies {
-        androidTestCompile "org.mockito:mockito-core:1.9.5"
-        androidTestCompile "com.google.dexmaker:dexmaker:1.2"
-        androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
+        androidTestImplementation "org.mockito:mockito-core:1.9.5"
+        androidTestImplementation "com.google.dexmaker:dexmaker:1.2"
+        androidTestImplementation "com.google.dexmaker:dexmaker-mockito:1.2"
     }
 }

--- a/AuthenticatorApp/build.gradle
+++ b/AuthenticatorApp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.2'
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {

--- a/AuthenticatorApp/src/main/AndroidManifest.xml
+++ b/AuthenticatorApp/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
           package="com.google.android.apps.authenticator2"
           android:versionCode="21" android:versionName="2.21">
 
-  <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="14" />
+  <uses-sdk android:targetSdkVersion="14" />
 
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.INTERNET" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 05 15:23:38 SGT 2017
+#Fri Jul 13 21:01:44 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 13 21:01:44 PDT 2018
+#Wed Sep 26 21:31:16 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This PR change the build files to work with the latest of the Gradle tools that came out with Android Studio 3.2