### PR TITLE
Issue VACCUM SQL directive to prevent the DB from keeping old Seeds

### DIFF
--- a/java/com/google/android/apps/authenticator/otp/AccountDb.java
+++ b/java/com/google/android/apps/authenticator/otp/AccountDb.java
@@ -637,6 +637,7 @@ public class AccountDb {
 
   public void delete(AccountIndex index) {
     mDatabase.delete(TABLE_NAME, whereClause(index), null);
+    mDatabase.execSQL("VACUUM");
   }
 
   /**


### PR DESCRIPTION
This is a re-patch of 69a69977470dc0b6c0cbccd165ef6d8baa5b451e, which was added in pull request #89.