### PR TITLE
Block screenshots

### DIFF
--- a/java/com/google/android/apps/authenticator/AuthenticatorActivity.java
+++ b/java/com/google/android/apps/authenticator/AuthenticatorActivity.java
@@ -56,6 +56,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
@@ -287,6 +288,10 @@ public class AuthenticatorActivity extends TestableActivity {
 
     totpCounter = otpProvider.getTotpCounter();
     totpClock = otpProvider.getTotpClock();
+
+
+    // Block screenshots
+    getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 
     setContentView(R.layout.main);
 

--- a/java/com/google/android/apps/authenticator/res/xml/preferences.xml
+++ b/java/com/google/android/apps/authenticator/res/xml/preferences.xml
@@ -29,4 +29,8 @@
                     android:persistent="false">
     <intent android:action="com.google.android.apps.authenticator.settings.ABOUT" />
   </PreferenceScreen>
+  <SwitchPreference
+      android:defaultValue="true"
+      android:key="blockScreenshotsEnabled"
+      android:title="Block Screenshots" />
 </PreferenceScreen>


### PR DESCRIPTION
## Change Description

This adds a toggleable setting to block screenshots from the main AuthenticatorActivity. By default that setting is set to `true`. Fixes #50 

Unfortunately I haven't been able to run the tests as they make my poor laptop go OOM. I tested it on a test device though. I've also had to upgrade the build tools etc to get the project to run, but I omitted it from this PR to keep it contained. 

