### PR TITLE
Stop pinning build_tools version in the Android SDK config

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,6 @@ android_sdk_repository(
     name = "androidsdk",
     api_level = 29,
     # path = "/path/to/sdk",
-    build_tools_version = "29.0.3"
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
Bazel CI is updating to build-tools 30.x.x. This allows for more flexibility with changing Bazel CI SDK versions.

https://github.com/bazelbuild/continuous-integration/pull/984